### PR TITLE
BayesianNetworkSampler with latent variables

### DIFF
--- a/core/src/main/java/eu/amidst/core/utils/BayesianNetworkSampler.java
+++ b/core/src/main/java/eu/amidst/core/utils/BayesianNetworkSampler.java
@@ -64,9 +64,7 @@ public class BayesianNetworkSampler implements AmidstOptionsHandler, Serializabl
     /** Represents a {@code Map} containing the noisy variables. */
     private Map<Variable, Double> marNoise = new HashMap();
 
-    /**
-     * Respresents a {@code Map} containing the latent variables.
-     */
+    /** Represents a {@code Map} containing the latent variables. */
     private Map<Variable, Boolean> latentVars = new HashMap();
 
     /**
@@ -92,7 +90,8 @@ public class BayesianNetworkSampler implements AmidstOptionsHandler, Serializabl
 
 
     /**
-     * Sets a given {@link Variable} object as hidden.
+     * Sets a given {@link Variable} object as hidden. A hidden variable contains an attribute whose values may be missing
+     * (some or all of them). In this case, numeric values won't be assigned and they will be represented by an "?" symbol.
      * @param var a given {@link Variable} object.
      */
     public void setHiddenVar(Variable var) {
@@ -108,8 +107,7 @@ public class BayesianNetworkSampler implements AmidstOptionsHandler, Serializabl
 
     /**
      * Sets a given {@link Variable} object as latent. A latent variable doesn't contain an attribute and therefore
-	 doesnt generate a sampling value.
-     *
+	 * doesn't generate a sampling value.
      * @param var a given {@link Variable} object.
      */
     public void setLatentVar(Variable var){


### PR DESCRIPTION
La mejora permite que la clase trabaje con redes Bayesianas con variables ocultas de tal forma que no les de un valor Double.NaN sino que directamente las ignore y el stream no genere atributos (ni por lo tanto Assignments) para ellas.

Esto tiene sentido por ejemplo cuando hacemos clustering con redes Bayesianas ya que esas variables se han aprendido utilizando un algoritmo especifico de aprendizaje de estructura y que en mi opinion no deberian aparecer en el dataset generado (ni siquiera con el simbolo "?"), para asi distinguir entre variable totalmente oculta de la cual el usuario no tiene constancia real de su existencia y una variable con valores missing (donde en mi opinion tiene sentido el "?").
